### PR TITLE
✨ feat : 메인페이지 게시글 좋아요 순 보여주기

### DIFF
--- a/consts/index.ts
+++ b/consts/index.ts
@@ -52,3 +52,5 @@ export const INIT_PLACE_FORM_VALUE = {
 
 export const DUMMY_IMAGE_URL =
   'https://ionwvcdgjauhpubafztg.supabase.co/storage/v1/object/public/place-images//no_image.jpeg';
+
+export const SORT_OPTIONS = ['인기순', '최신순', '평점순', '비용순'];


### PR DESCRIPTION
## 📌 작업 개요 (What)

메인페이지 좋아요순 정렬 (게시글)

---

## 🛠️ 작업 상세 (Details)

좋아요순 정렬 쿼리

```sql
-- PostgreSQL 함수: get_formatted_posts
drop function get_best_posts;
create or replace function get_best_posts (
  posts_limit INT default 30 -- 가져올 최대 게시물 수
) RETURNS table (
  id TEXT,
  title TEXT,
  region TEXT,
  author TEXT,
  imageUrl TEXT,
  startDate TEXT,
  endDate TEXT,
  createdAt TEXT,
  views INT,
  likes INT,
  cost INT
) LANGUAGE plpgsql as $$
BEGIN
    RETURN QUERY
    SELECT
        p.id::TEXT AS id, -- int8을 TEXT로 변환
        p.title AS title,
        r_state.name || ' ' || r_city.name AS region,
        up.name AS author,
        thumbnail_img.image_url AS imageUrl, 
        TO_CHAR(pl.visit_start_time, 'YYYY-MM-DD') AS startDate,
        TO_CHAR(pl.visit_end_time, 'YYYY-MM-DD') AS endDate,     
        TO_CHAR(p.created_at, 'YYYY-MM-DD') AS createdAt,
        COALESCE(view_counts.views_count, 0)::INT AS views,
        COALESCE(like_counts.like_count::INT, 0) AS likes,     
        COALESCE(sum_costs.sum_cost::INT, 0) AS cost  
    FROM
        posts AS p
    LEFT JOIN
        user_profiles AS up ON p.user_id = up.id
    LEFT JOIN
        places AS pl ON p.representative_place_id = pl.id
    LEFT JOIN
        regions_city AS r_city ON pl.city_id = r_city.id
    LEFT JOIN
        regions_state AS r_state ON r_city.state_id = r_state.id
    LEFT JOIN
        place_images AS thumbnail_img ON pl.thumbnail_image_id = thumbnail_img.id
    LEFT JOIN (
        -- 서브쿼리: 각 게시물별 조회수 계산
        SELECT
            pvl.post_id,
            COUNT(pvl.post_id) AS views_count
        FROM
            post_view_logs as pvl
        GROUP BY
            pvl.post_id
    ) AS view_counts ON p.id = view_counts.post_id
    LEFT JOIN (
        -- 서브쿼리: 각 게시물별 좋아요수 계산
        SELECT 
            pli.post_id,
            COUNT(pli.post_id) as like_count
        FROM 
            post_likes as pli
        GROUP
            BY pli.post_id
    ) AS like_counts ON like_counts.post_id = p.id
    LEFT JOIN (
        -- 서브쿼리: 게시글 여행지의 비용 합산
        SELECT
            pp.post_id,
            SUM(pl.cost) AS sum_cost
        FROM
            post_places AS pp
        JOIN
            places AS pl ON pp.place_id = pl.id
        GROUP BY
            pp.post_id
    ) AS sum_costs ON p.id = sum_costs.post_id
    ORDER BY
        like_counts.like_count DESC
    LIMIT posts_limit;
END;
$$;

-- 테스트코드 상위 6개
select
  *
from
  get_best_posts (6);
```

---

## 🔖 관련 이슈

#77 

---

## ✅ 체크리스트

- [ ] 기능이 정상 작동하는지 확인했나요?
- [x] Prettier로 코드 정리했나요? (`Format on Save`)
- [x] 불필요한 콘솔/주석은 제거했나요?
- [x] 에러/경고 없이 실행되나요?
- [x] 관련 이슈와 연결되었나요?
- [ ] 기능 구현이 완료되었나요?
- [x] 브랜치 충돌이 없나요?

---

## 🔍 기타 참고 사항

❗❗❗ **imageUrl**의 경우 제대로 데이터가 전달됨을 로그를 통해서 확인하였으나, 엑박이 뜨는 상황입니다.

여행지 기준은 추가 작성 예정입니다.

api가 먹통이 되는 경우가 많아 테스트환경이 불안정해 작업된 부분까지 PR 올렸습니다.

데이터를 db에서 불러온 후 화면을 그리는 `PostCard.tsx`의 `PostCardProps`와 필드와 맞지 않습니다.

- category는 post에는 없어서 제외하였고 rating, ratingCount, duration와 관련된 쿼리를 작성중입니다.

```js
// 쿼리 결과 타입 정의 아직 사용되지 않음 (PostCard에서 category, rating, ratingCount, duration 제외)
interface BestPostQueryResult {
  id: string;
  title: string;
  region: string;
  author: string;
  views: number;
  cost: number;
  imageUrl: string;
  startDate: string;
  endDate: string;
  createdAt: string;
  likes: number;
}
```

